### PR TITLE
fix: structure alignment bug

### DIFF
--- a/DFRobot_DF2301Q.h
+++ b/DFRobot_DF2301Q.h
@@ -231,6 +231,8 @@ public:
     // uint8_t tail;   /* send add auto */
   }sUartMsg_t;
 
+  #pragma pack()
+
   /**
    * @enum eReceiveState_t
    * @brief receive use state machine method, so two char can arrive different time


### PR DESCRIPTION
The #pragma pack(1) needs to be paired with #pragma pack(), otherwise it may cause errors when compiling with other libraries.

Tested in this issue
#12 